### PR TITLE
Fix removeEventListener

### DIFF
--- a/src/widget/element.ts
+++ b/src/widget/element.ts
@@ -104,7 +104,7 @@ export abstract class SKElement {
   ) {
     this.bindingTable = this.bindingTable.filter(
       (d) =>
-        d.type != type && d.handler != handler && d.capture != capture
+        !(d.type == type && d.handler == handler && d.capture == capture)
     );
   }
 


### PR DESCRIPTION
The original implementation of `removeEventListener` actually removes listeners that match any of the properties. We should remove only those that match all of the properties.