### PR TITLE
Reset content sizes to 0 when container empty

### DIFF
--- a/src/widget/container.ts
+++ b/src/widget/container.ts
@@ -60,6 +60,9 @@ export class SKContainer extends SKElement {
       const size = this._layoutMethod.measure(this._children);
       this.contentWidth = size.width;
       this.contentHeight = size.height;
+    } else {
+      this.contentWidth = 0;
+      this.contentHeight = 0;
     }
     super.measure();
   }


### PR DESCRIPTION
Without resetting content widths on empty containers, previously-filled containers can be drawn with the wrong width/heights once made empty.